### PR TITLE
update requirements.txt and README to be compatible with Ubuntu 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@
 
 ## Setup
 ```
+# on Ubuntu
+sudo apt-get install -y libavformat-dev libavdevice-dev
+
+# install Python dependencies
 pip install -r requirements.txt
 ```
-Tested with WinPython 3.11 and CUDA V11.7
+Tested
+- with WinPython 3.11 and CUDA V11.7
+- on Ubuntu 24.04 with Python 3.12 and CPU
 
 
 ## Download models

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 customtkinter
 CTkListbox
 faster-whisper
-ctranslate2==3.24.0
+ctranslate2==4.5.0
 sentencepiece
 huggingface_hub
+srt==3.5.3


### PR DESCRIPTION
I had problems running this tool on my Ubuntu machine:
- First, some packages had to be installed on the system. I added this info to the README.
- Secondly, the version of ctranslate2 in `requirements.txt` is pretty outdated, and was the cause of errors on my up-to-date Ubuntu. Updating from 3.24.0 to 4.5.0 fixed that
- Finally, there was a pip requirement missing: srt

Btw: It might be a good idea to pin the versions of the other requirements, in order to get reproducible results.